### PR TITLE
Add config option for GameAPI include path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ pip install urwid
   - After creation, you can optionally run `project_update` to generate new `All.cpp` and `All.hpp` files.
 
 ## gameapi_util_cfg
-`gameapi_util_cfg.py` is used for configuring various things, such as - the path to your objects directory. Many options are available:
+`gameapi_util_cfg.py` is used for configuring various things, such as the path to your objects directory. Many options are available:
 ```
 GAME_PATH        = "src"
 OBJECT_PATH_NAME = "Objects"
 ALL_CODE_NAME    = "All.cpp"
 ALL_HEADER_NAME  = "All.hpp"
+GAMEAPI_INC_PATH = "Game.hpp"
 PUB_FNS_PATH     = "PublicFunctions.hpp"
 OBJECT_NAMESPACE = "GameLogic"
 

--- a/gameapi_util_cfg.py
+++ b/gameapi_util_cfg.py
@@ -17,7 +17,7 @@ GAME_PATH        = 'src'
 OBJECT_PATH_NAME = 'Objects'
 ALL_CODE_NAME    = 'All.cpp'
 ALL_HEADER_NAME  = 'All.hpp'
-GAMEAPI_PATH     = 'Game.hpp'
+GAMEAPI_INC_PATH = 'Game.hpp'
 PUB_FNS_PATH     = f'{GAME_PATH}/PublicFunctions.hpp'
 OBJECT_NAMESPACE = 'GameLogic'
 

--- a/gameapi_util_cfg.py
+++ b/gameapi_util_cfg.py
@@ -17,6 +17,7 @@ GAME_PATH        = 'src'
 OBJECT_PATH_NAME = 'Objects'
 ALL_CODE_NAME    = 'All.cpp'
 ALL_HEADER_NAME  = 'All.hpp'
+GAMEAPI_PATH     = 'Game.hpp'
 PUB_FNS_PATH     = f'{GAME_PATH}/PublicFunctions.hpp'
 OBJECT_NAMESPACE = 'GameLogic'
 

--- a/gameapi_util_cpp.py
+++ b/gameapi_util_cpp.py
@@ -135,7 +135,7 @@ class gameapi_util:
                 self.loopState = self.loop_wait_for_return
                 return
 
-            object_cpp = f"""#include "{config.GAMEAPI_PATH}"
+            object_cpp = f"""#include "{config.GAMEAPI_INC_PATH}"
 
 using namespace RSDK;
 
@@ -180,7 +180,7 @@ void {self.obj_name}::Serialize() {{}}
 """
 
             object_hpp = f"""#pragma once
-#include "{config.GAMEAPI_PATH}"
+#include "{config.GAMEAPI_INC_PATH}"
 
 using namespace RSDK;
 
@@ -325,7 +325,7 @@ struct {self.obj_name} : GameObject::Entity {{
 
         with open(config.PUB_FNS_PATH, "w") as f:
             f.write('#pragma once\n')
-            f.write(f'#include "{config.GAMEAPI_PATH}"')
+            f.write(f'#include "{config.GAMEAPI_INC_PATH}"')
             f.write('\n\nusing namespace RSDK;\n\n')
             f.write('#if RETRO_USE_MOD_LOADER\n')
 

--- a/gameapi_util_cpp.py
+++ b/gameapi_util_cpp.py
@@ -135,7 +135,7 @@ class gameapi_util:
                 self.loopState = self.loop_wait_for_return
                 return
 
-            object_cpp = f"""#include "Game.hpp"
+            object_cpp = f"""#include "{config.GAMEAPI_PATH}"
 
 using namespace RSDK;
 
@@ -180,7 +180,7 @@ void {self.obj_name}::Serialize() {{}}
 """
 
             object_hpp = f"""#pragma once
-#include "Game.hpp"
+#include "{config.GAMEAPI_PATH}"
 
 using namespace RSDK;
 
@@ -325,7 +325,7 @@ struct {self.obj_name} : GameObject::Entity {{
 
         with open(config.PUB_FNS_PATH, "w") as f:
             f.write('#pragma once\n')
-            f.write('#include "RSDKv5/RSDKv5.hpp"')
+            f.write(f'#include "{config.GAMEAPI_PATH}"')
             f.write('\n\nusing namespace RSDK;\n\n')
             f.write('#if RETRO_USE_MOD_LOADER\n')
 


### PR DESCRIPTION
Allows for configuring the GameAPI include path, since it can vary from project to project.
Also, not sure if there was a reason for the public function generator including `RSDKv5/RSDKv5.hpp` instead of  `Game.hpp` (which includes RSDKv5.hpp itself), but I changed it to include the same path as the All updater.