### PR TITLE
Add option to only show options for one coding language

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ pip install urwid
 ## Default Functions
 
 - **Project Update**
-  - Generates `All.c/All.cpp`, which can be used in your Visual Studio or CMake project. This can speed up build times by compiling every object at once, instead of compiling them separately.
+  - Generates `All.c/All.cpp` and `All.h/All.hpp`, which can be used in your Visual Studio or CMake project. This can speed up build times by compiling every object at once, instead of compiling them separately.
   - Generates `Objects.cmake`, which can be used instead of `All.c/All.cpp`, if you'd like to build the objects separately.
 
 - **Generate public functions**
-  - Generates public functions for the RSDKv5U decompilation's modding API. Entity events are not included.
+  - Generates public functions for the RSDKv5(U) Decompilation's modding API. Entity events are not included.
 
 - **New Object** [default]
   - Creates a new object in the specified directory.
@@ -36,19 +36,20 @@ pip install urwid
 
 **Available options:**
 ```py
-GAME_PATH        = "src"
-OBJECT_PATH_NAME = "Objects"
-ALL_CODE_NAME    = "All.cpp"
-ALL_HEADER_NAME  = "All.hpp"
-GAMEAPI_INC_PATH = "Game.hpp"
-PUB_FNS_PATH     = "PublicFunctions.hpp"
-OBJECT_NAMESPACE = "GameLogic"
+# Path configuration
+GAME_PATH        = 'src'
+OBJECT_PATH_NAME = 'Objects'
+ALL_CODE_NAME    = 'All.cpp'
+ALL_HEADER_NAME  = 'All.hpp'
+GAMEAPI_INC_PATH = 'Game.hpp'
+PUB_FNS_PATH     = f'{GAME_PATH}/PublicFunctions.hpp'
+OBJECT_NAMESPACE = 'GameLogic'
 
-# cmake configuration
-CMAKE_PATH = "Objects.cmake"
-GAME_NAME  = "${GAME_NAME}" # The game directory to look into
+# CMake configuration
+CMAKE_PATH = 'Objects.cmake'
+GAME_NAME  = '${GAME_NAME}' # The game directory to look into
 
-OBJECT_PATH = f"{GAME_PATH}/{OBJECT_PATH_NAME}"
+OBJECT_PATH = f'{GAME_PATH}/{OBJECT_PATH_NAME}'
 ```
 
 ## Extending the main menu
@@ -62,7 +63,6 @@ def init(app_in):
     app.add_option('Validate Objects', object_validity_check)
     app.add_option('Check Status', project_status_check)
     app.spacer()
-# init -> (app_in)
 ```
 
 ![Screenshot of the main interface, after being extended by gameapi_util_cfg.py](/screenshots/main_extended.png)

--- a/gameapi_util.py
+++ b/gameapi_util.py
@@ -1225,11 +1225,18 @@ def main():
     app = gameapi_util()
 
     if config.skipDefaultTools == False:
-        app.menu_add_cpp_tools()
-        app.spacer()
+        if config.language == 0:
+            app.menu_add_cpp_tools()
+            app.spacer()
 
-        app.menu_add_c_tools()
-        app.spacer()
+            app.menu_add_c_tools()
+            app.spacer()
+        elif config.language == 1:
+            app.menu_add_c_tools()
+            app.spacer()
+        elif config.language == 2:
+            app.menu_add_cpp_tools()
+            app.spacer()
 
     config.init(app)
     app.add_option("Exit", app.exit_util)

--- a/gameapi_util_cfg.py
+++ b/gameapi_util_cfg.py
@@ -7,8 +7,12 @@ import os
 # If you'd prefer to skip some options, but keep
 # specific ones in, you can add them back, via the
 # init function. For example:
-# app.add_option("Update All.cpp/hpp & CMake Project", app.project_update)
+# app.add_option("Project Update", lambda: app.project_update(0))
 skipDefaultTools = False
+
+# Use this to only show default options for one coding language.
+# 0 = Show all, 1 = C, 2 = C++
+language = 0
 
 # Path configuration
 GAME_PATH        = 'src'
@@ -19,7 +23,7 @@ GAMEAPI_INC_PATH = 'Game.hpp'
 PUB_FNS_PATH     = f'{GAME_PATH}/PublicFunctions.hpp'
 OBJECT_NAMESPACE = 'GameLogic'
 
-# cmake configuration
+# CMake configuration
 CMAKE_PATH = 'Objects.cmake'
 GAME_NAME  = '${GAME_NAME}' # The game directory to look into
 
@@ -31,4 +35,3 @@ app = None
 def init(app_in):
     global app
     app = app_in
-# init -> (app_in)


### PR DESCRIPTION
Adds a `language` option to gameapi_util_cfg to only show the default options for one of the coding languages. It will still show both language's options by default, but setting the option to 1 or 2 will only show the options for C or C++, respectively.

Also updated the add_option example to set the language mode and the README config options to match what's in the default config file.