### PR TITLE
Readd ALL_CODE_PATH and ALL_HEADER_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ CMAKE_PATH = "Objects.cmake"
 GAME_NAME  = "${GAME_NAME}" # The game directory to look into
 
 OBJECT_PATH = f"{GAME_PATH}/{OBJECT_PATH_NAME}"
+ALL_CODE_PATH = f'{OBJECT_PATH}/{ALL_CODE_NAME}'
+ALL_HEADER_PATH = f'{GAME_PATH}/{ALL_HEADER_NAME}'
 ```
 
 ## Extending the main menu

--- a/gameapi_util.py
+++ b/gameapi_util.py
@@ -1139,8 +1139,16 @@ class gameapi_util:
                 rel_dir = os.path.relpath(dir_, config.OBJECT_PATH)
                 filenames.append(f"{rel_dir}/{file_name}")
 
+            obj_rel_dir = '' if os.path.dirname(config.ALL_CODE_PATH) == config.OBJECT_PATH else os.path.relpath(config.OBJECT_PATH, os.path.dirname(config.ALL_CODE_PATH)).replace("\\","/") + '/'
+            obj_includes = [
+                f'#include "{name}"\n'
+                for f in filenames
+                if f.endswith(codeExtension) and not f.endswith(config.ALL_CODE_NAME)
+                for name in [obj_rel_dir + f]
+            ]
+
             with open(config.ALL_CODE_PATH, "w") as f:
-                f.writelines(f'#include "{f}"\n' for f in filenames if f.endswith(codeExtension) and not f.endswith(config.ALL_CODE_NAME))
+                f.writelines(obj_includes)
 
             obj_forward_decl = [
                 f'typedef struct Object{name} Object{name};\ntypedef struct Entity{name} Entity{name};\n' if mode == 1 else f'struct {name};\n'
@@ -1149,7 +1157,13 @@ class gameapi_util:
                 for name in [os.path.splitext(os.path.basename(f))[0]]
             ]
 
-            obj_includes = [f'#include "{config.OBJECT_PATH_NAME}/{f}"\n' for f in filenames if f.endswith(headerExtension) and not f.endswith(config.ALL_HEADER_NAME)]
+            obj_rel_dir = '' if os.path.dirname(config.ALL_HEADER_PATH) == config.OBJECT_PATH else os.path.relpath(config.OBJECT_PATH, os.path.dirname(config.ALL_HEADER_PATH)).replace("\\","/") + '/'
+            obj_includes = [
+                f'#include "{name}"\n'
+                for f in filenames
+                if f.endswith(headerExtension) and not f.endswith(config.ALL_HEADER_NAME)
+                for name in [obj_rel_dir + f]
+            ]
 
             if mode == 0: # C++
                 with open(config.ALL_HEADER_PATH, "w") as f:

--- a/gameapi_util.py
+++ b/gameapi_util.py
@@ -1139,7 +1139,7 @@ class gameapi_util:
                 rel_dir = os.path.relpath(dir_, config.OBJECT_PATH)
                 filenames.append(f"{rel_dir}/{file_name}")
 
-            with open(f'{config.OBJECT_PATH}/{config.ALL_CODE_NAME}', "w") as f:
+            with open(config.ALL_CODE_PATH, "w") as f:
                 f.writelines(f'#include "{f}"\n' for f in filenames if f.endswith(codeExtension) and not f.endswith(config.ALL_CODE_NAME))
 
             obj_forward_decl = [
@@ -1152,14 +1152,14 @@ class gameapi_util:
             obj_includes = [f'#include "{config.OBJECT_PATH_NAME}/{f}"\n' for f in filenames if f.endswith(headerExtension) and not f.endswith(config.ALL_HEADER_NAME)]
 
             if mode == 0: # C++
-                with open(f'{config.GAME_PATH}/{config.ALL_HEADER_NAME}', "w") as f:
+                with open(config.ALL_HEADER_PATH, "w") as f:
                     f.write('#pragma once\n')
                     f.write(f'namespace {config.OBJECT_NAMESPACE}\n{{\n\n')
                     f.writelines(obj_forward_decl)
                     f.write(f'\n}} // namespace {config.OBJECT_NAMESPACE}\n\n')
                     f.writelines(obj_includes)
             elif mode == 1: # C
-                with open(f'{config.GAME_PATH}/{config.ALL_HEADER_NAME}', "w") as f:
+                with open(config.ALL_HEADER_PATH, "w") as f:
                     f.write('// Forward Declarations\n')
                     f.writelines(obj_forward_decl)
                     f.writelines('\n')

--- a/gameapi_util_cfg.py
+++ b/gameapi_util_cfg.py
@@ -24,6 +24,8 @@ CMAKE_PATH = 'Objects.cmake'
 GAME_NAME  = '${GAME_NAME}' # The game directory to look into
 
 OBJECT_PATH = f'{GAME_PATH}/{OBJECT_PATH_NAME}'
+ALL_CODE_PATH = f'{OBJECT_PATH}/{ALL_CODE_NAME}'
+ALL_HEADER_PATH = f'{GAME_PATH}/{ALL_HEADER_NAME}'
 
 # Function/Variable definitions
 app = None


### PR DESCRIPTION
Brings back `ALL_CPP_PATH` and `ALL_HPP_PATH`, renamed to `ALL_CODE_PATH` and `ALL_HEADER_PATH` respectively, which were removed in a2cdf99 with no given reason as to why. I personally prefer to have All.hpp in the Objects folder, and I don't think that I should have to replace the default Project Update function with a custom implementation just to change what path the file is saved to.